### PR TITLE
Fix Issue74: Confluence migration fails from subwikis

### DIFF
--- a/application-confluence-migrator-api/src/main/java/com/xwiki/confluencemigrator/internal/DefaultConfluenceMigratorProfile.java
+++ b/application-confluence-migrator-api/src/main/java/com/xwiki/confluencemigrator/internal/DefaultConfluenceMigratorProfile.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -91,6 +92,7 @@ public class DefaultConfluenceMigratorProfile implements ConfluenceMigratorProfi
         new LocalDocumentReference(Arrays.asList(CONFLUENCE, TOOLS), "ActiveMigrationProfileClass");
 
     @Inject
+    @Named("currentmixed")
     private DocumentReferenceResolver<String> resolver;
 
     @Inject

--- a/application-confluence-migrator-ui/src/main/resources/Confluence/Migrator/Code/MigratorSheet.xml
+++ b/application-confluence-migrator-ui/src/main/resources/Confluence/Migrator/Code/MigratorSheet.xml
@@ -328,8 +328,9 @@ require(['jquery', 'xwiki-events-bridge', 'SmartWizard'], function($, xev, Smart
         $(".sw-btn-next").removeClass('hidden');
       }
     });
+    return true;
   }
-  XWiki.domIsLoaded &amp;&amp; initWizard();
+  XWiki.domIsLoaded &amp;&amp; initWizard() || $(document).on("xwiki:dom:loaded", initWizard)
 
   $(document).on('xwiki:html5upload:fileFinished', function() {
     var fileName = $('#attachform .upload-status:last-of-type span.file-name').html();

--- a/application-confluence-migrator-ui/src/main/resources/Confluence/Tools/NestedPagesMigration.xml
+++ b/application-confluence-migrator-ui/src/main/resources/Confluence/Tools/NestedPagesMigration.xml
@@ -210,13 +210,14 @@ The Nested Spaces Migrator 0.8 is currently incompatible with the Confluence Mig
   &lt;div class="row"&gt;
   &lt;div class="col-xs-12 col-md-6"&gt;
     &lt;input type="hidden" id="includedSpaces" data-bind="value: configuration.includedSpaces"&gt;
+    &lt;input type="hidden" id="excludedSpaces" data-bind="value: []"&gt;
   &lt;/div&gt;
   &lt;div class="col-xs-12 col-md-6"&gt;
     &lt;p&gt;&lt;button class="btn btn-default hidden" type="button" data-toggle="collapse" data-target="#advancedSettings" aria-expanded="false" aria-controls="advancedSettings"&gt;Advanced Settings&lt;/button&gt;&lt;/p&gt;
     &lt;dl id="advancedSettings" class="collapse well"&gt;
       &lt;!-- Exclude hidden pages --&gt;
       &lt;dt&gt;&lt;input type="checkbox" id="excludeHiddenPages" data-bind="checked: configuration.excludeHiddenPages"&gt; &lt;label for="excludeHiddenPages"&gt;Exclude hidden pages&lt;/label&gt;&lt;/dt&gt;
-      &lt;dd&gt;&lt;span class="xHint"&gt;Most of the hidden pages are techinal content. Moving them can break applications.&lt;/span&gt;&lt;/dd&gt;
+      &lt;dd&gt;&lt;span class="xHint"&gt;Most of the hidden pages are technical content. Moving them can break applications.&lt;/span&gt;&lt;/dd&gt;
       &lt;!-- Exclude class pages --&gt;
       &lt;dt&gt;&lt;input type="checkbox" id="excludeClassPages" data-bind="checked: configuration.excludeClassPages"&gt; &lt;label for="excludeClassPages"&gt;Exclude pages having a class&lt;/label&gt;&lt;/dt&gt;
       &lt;dd&gt;&lt;span class="xHint"&gt;The pages are technical and moving them can break applications.&lt;/span&gt;&lt;/dd&gt;


### PR DESCRIPTION
Using a different DocumentResolver makes sure calls that in from a subwiki page names are resolved to the current subwiki, instead of the main wiki.

Also could not resist to include a few minor improvements. If that is not wanted, I will revert them for this PR and create separate ones.