### PR TITLE
Prefix confluence attachments macro

### DIFF
--- a/application-confluence-migrator-ui/src/main/resources/Confluence/Tools/Filter.xml
+++ b/application-confluence-migrator-ui/src/main/resources/Confluence/Tools/Filter.xml
@@ -152,7 +152,7 @@
   'input' : {
     'verbose' : 'false',
     'usersEnabled' : 'false',
-    'prefixedMacros' : 'chart, gallery',
+    'prefixedMacros' : 'chart, gallery, attachments',
     'baseURLs' : "$!activeProfileDoc.getValue('url')",
     'storeConfluenceDetailsEnabled': true
   },


### PR DESCRIPTION
Add confluence attachment macro to the list of prefixed macros
See https://github.com/xwikisas/xwiki-pro-macros/pull/87#discussion_r992111700